### PR TITLE
catch request errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -86,6 +86,7 @@ module.exports.request = (url, method, options = {}) => new Promise((resolve, re
     res.on('timeout', () => reject(req));
   });
 
+  req.on('error', reject);
   req.write(options.body || '');
   req.end();
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -95,4 +95,6 @@ describe('index.js', () => {
       should(typeof response.body).eql('string');
     }));
 
+  it('request exception', () => client.get('http://foobar:7777/')
+    .catch(err => should(err).be.instanceof(Error).and.be.match({message: 'getaddrinfo ENOTFOUND foobar foobar:7777'})));
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -96,5 +96,5 @@ describe('index.js', () => {
     }));
 
   it('request exception', () => client.get('http://foobar:7777/')
-    .catch(err => should(err).be.instanceof(Error).and.be.match({message: 'getaddrinfo ENOTFOUND foobar foobar:7777'})));
+    .catch(err => should(err).be.instanceof(Error).and.match({message: 'getaddrinfo ENOTFOUND foobar foobar:7777'})));
 });


### PR DESCRIPTION
If we have an error when sending a request (for example if the server address is not found), we have an uncaught exception.

This PR fix that: it catches request errors and call the promise rejection in that case.